### PR TITLE
Make L68/S68 output more like EASy68K

### DIFF
--- a/ASM68Kv5.15.4/ASSEMBLE.CPP
+++ b/ASM68Kv5.15.4/ASSEMBLE.CPP
@@ -173,6 +173,19 @@ string ChangeFileExt(string in, const string& newExt) {
    return s;
 }
 #endif
+
+//--- added by github.com/dmo2118
+void REMOVECR(char *line)
+{
+  size_t len = strnlen(line, 256);
+  if (len >= 2) {
+    char *end = line + len;
+    if (end[-2] == '\r' && end[-1] == '\n') {
+      end[-2] = '\n';
+      end[-1] = 0;
+    }
+  }
+}
 //------------------------------------------------------------
 
 //------------------------------------------------------------
@@ -344,7 +357,8 @@ int processFile()
       skipCond = false;             // true conditionally skips lines in code
       while(!endFlag && fgets(line, 256, inFile)) {
 
-        // RA - not sure I still need this; handle MSDOS/Win line endings by convering CR's to spaces - hacky, I know
+        // RA - not sure I still need this.
+        // Handle MSDOS/Win line endings by chomping the CR in the CRLF.
         REMOVECR(line); 
 
         error = OK;

--- a/ASM68Kv5.15.4/DIRECTIV.CPP
+++ b/ASM68Kv5.15.4/DIRECTIV.CPP
@@ -277,7 +277,7 @@ int equ(int size, char *label, char *op, int *errorPtr)
       }	else {
 	define(label, value, pass2, true, errorPtr);
 	if (pass2 && listFlag && *errorPtr < MINOR) {
-	  sprintf(listPtr, "=%08lX ", (long) value); // RA suppress warning on modern 64 bit machines
+	  sprintf(listPtr, "=%08X ", value); // RA suppress warning on modern 64 bit machines
 	  listPtr += 10;
 	}
       }
@@ -320,7 +320,7 @@ int set(int size, char *label, char *op, int *errorPtr)
 	symbol = define(label, value, pass2, false, &error);   // ck 4-18-03
 	symbol->flags |= REDEFINABLE;
 	if (pass2 & listFlag) {
-	  sprintf(listPtr, "=%08lX ", (long)value); // supress size warning on 64 bit machines
+	  sprintf(listPtr, "=%08X ", value); // supress size warning on 64 bit machines
 	  listPtr += 10;
 	}
       }

--- a/ASM68Kv5.15.4/LISTING.CPP
+++ b/ASM68Kv5.15.4/LISTING.CPP
@@ -196,9 +196,9 @@ int listLoc()
   if (!listPtr) listPtr=listData; // prevent crash RA
 
   if (offsetMode || showEqual)
-    sprintf(listData, "%08lX= ", (long) loc); //RA warning: format ‘%lX’ expects argument of type ‘long unsigned int’, but argument 3 has type ‘int’
+    sprintf(listData, "%08X= ", loc); //RA warning: format ‘%lX’ expects argument of type ‘long unsigned int’, but argument 3 has type ‘int’
   else
-    sprintf(listData, "%08lX  ", (long) loc); // RA
+    sprintf(listData, "%08X  ", loc); // RA
   listPtr = listData + 10;
 
   return NORMAL;
@@ -257,7 +257,7 @@ int listObj(int data, int size)
     case WORD_SIZE: sprintf(listPtr, "%04X ", (unsigned int)(data & 0xFFFF)); // RA
       listPtr += 5;
       break;
-    case LONG_SIZE: sprintf(listPtr, "%08lX ", (long)(data)); // RA
+    case LONG_SIZE: sprintf(listPtr, "%08X ", data); // RA
       listPtr += 9;
       break;
     default: sprintf(buffer,"LISTOBJ: INVALID SIZE CODE!\n");
@@ -296,7 +296,7 @@ int finishList()
 
     // write starting address to first line of file
     rewind(listFile);                     // rewind to start of file
-    fprintf(listFile, "%08lX", (long) startAddress);
+    fprintf(listFile, "%08X", startAddress);
 
     fclose(listFile);
     return NORMAL;

--- a/ASM68Kv5.15.4/OBJECT.CPP
+++ b/ASM68Kv5.15.4/OBJECT.CPP
@@ -191,7 +191,7 @@ int outputObj(int newAddr, int data, int size)
 	sprintf(sRecord, "S2  %06X", (int) newAddr); //RA
 	obyteCount = 4;
       }	else {
-	sprintf(sRecord, "S3  %08lX", (long) newAddr); //RA warning: format ‘%lX’ expects argument of type ‘long unsigned int’, but argument 3 has type ‘int’
+	sprintf(sRecord, "S3  %08X", newAddr); //RA warning: format ‘%lX’ expects argument of type ‘long unsigned int’, but argument 3 has type ‘int’
 	obyteCount = 5;
       }
       objPtr = sRecord + 4 + (obyteCount-1)*2;
@@ -212,7 +212,7 @@ int outputObj(int newAddr, int data, int size)
 	obyteCount += 2;
 	break;
       case LONG_SIZE :
-        sprintf(objPtr, "%08lX", (long) data); // RA
+        sprintf(objPtr, "%08X", data); // RA
 	obyteCount += 4;
 	break;
       default :

--- a/ASM68Kv5.15.4/OBJECT.CPP
+++ b/ASM68Kv5.15.4/OBJECT.CPP
@@ -252,7 +252,7 @@ int writeObj()
       str += *sRec++;
       str += *sRec++;
 //      checksum += (char) (StrToInt(str) & 0xFF); //RA
-      checksum += (char) (atoi(str.c_str()) & 0xFF); //RA
+      checksum += (char) (strtol(str.c_str(), NULL, 0) & 0xFF); //RA
     }
     sprintf(sRec, "%02X\n", (~checksum & 0xFF)); // put checksum in sRecord
 

--- a/ASM68Kv5.15.4/STRUCTURED.CPP
+++ b/ASM68Kv5.15.4/STRUCTURED.CPP
@@ -13,10 +13,9 @@
 #include <string.h>
 #include "asm.h"
 
+#include <algorithm>
 #include <stack>  // RA removed .h
 #include <vector> // RA removed .h
-#include <bits/stdc++.h> // RA added
-
 
 extern char line[256];		// Source line
 extern bool listFlag;

--- a/ASM68Kv5.15.4/asm.h
+++ b/ASM68Kv5.15.4/asm.h
@@ -40,7 +40,7 @@ using std::string;
 #define stricmp   strcasecmp
 #define strcmpi   strcasecmp
 #define strnicmpi strncasecmp
-#define REMOVECR(line)  { for (int i=0; line[i] && i<256; i++) if (line[i]==13) line[i]=' '; }
+void REMOVECR(char *line);
 //------------------
 
 /* Define a couple of useful tests */


### PR DESCRIPTION
For the following program,
```
derp    equ $FEDCBA98
        move.l #derp,d0
        end 0
```

This branch makes:
```
00000000 Starting Address
Assembler used: ASy68K Assembler v5.15.04
Created On: Thu Apr  9 01:09:08 2020


00000000  =FFFFFFFFFEDCBA98          1  derp    equ $FEDCBA98 
00000000  203C FFFFFFFFFEDCBA98      2          move.l #derp,d0 
00000006                             3          end 0 

No errors detected
No warnings generated


SYMBOL TABLE INFORMATION
Symbol-name         Value
-------------------------
DERP                FEDCBA98
```
...look more like:
```
00000000 Starting Address
Assembler used: EASy68K Editor/Assembler v5.16.01
Created On: 4/9/2020 12:31:37 AM

00000000  =FEDCBA98                  1  derp    equ $FEDCBA98
00000000  203C FEDCBA98              2          move.l #derp,d0
00000006                             3          end 0

No errors detected
No warnings generated


SYMBOL TABLE INFORMATION
Symbol-name         Value
-------------------------
DERP                FEDCBA98
```

And it makes:
```
S021000036384B50524F47202020323043524541544544204259204541535936384BFF
S1090000203CFFFFFFFFFF
S804000000FF
```
...look more like:
```
S021000036384B50524F47202020323043524541544544204259204541535936384B6D
S1090000203CFEDCBA986E
S804000000FB
```

Specific fixes are noted in the Git history.